### PR TITLE
MISC: Fix typos found in READMEs

### DIFF
--- a/HoloRepositoryDemoApplication/README.md
+++ b/HoloRepositoryDemoApplication/README.md
@@ -1,4 +1,4 @@
 # HoloRepository
 The COMP0111 project MSGOSHHOLO, where we develop a software engineering solution for Microsoft and GOSH.
 # HoloRepositoryDemoApplication
-This demo application is developed by Unity3D, the related development tools could be found in [microsoft mixed reality offical site](https://docs.microsoft.com/en-us/windows/mixed-reality/install-the-tools).
+This demo application is developed by Unity3D, the related development tools could be found in [microsoft mixed reality official site](https://docs.microsoft.com/en-us/windows/mixed-reality/install-the-tools).

--- a/HoloStorageConnector/README.md
+++ b/HoloStorageConnector/README.md
@@ -1,7 +1,7 @@
 # HoloStorageConnector
 HoloStorageConnector is used to provide an importable Unity asset package, to facilitate the development of HoloLens app with HoloStorage. This package build the connection with HoloStorage based on the [HoloStorage Accessor API](https://app.swaggerhub.com/apis/boonwj/HoloRepository/1.0.0#/). Current connector package is developed based on HoloStorage Accessor API version 1.0.0, you can access our main [GitHub repository](https://github.com/nbckr/HoloRepository-Core) to find more information about the HoloStorage Accessor server.
 
-**Important note**: Currently, the HoloStorageConnector script is developed inside the DemoApplication. This folder only contains a symbolic link to the package inside that applicatiton's `Assets/` in order to prevent duplicate code. Ideally, it would be the other way around. However, due to inconsistencies in how Windows supports symlinks, this can break the build (if the symlink is not recognised in a Windows development environment, the Connector namespace is missing in the demo app). For 3rd party developers to obtain the package they can copy the folder or, which is the recommended way, download the AssetPackage from a GitHub release. 
+**Important note**: Currently, the HoloStorageConnector script is developed inside the DemoApplication. This folder only contains a symbolic link to the package inside that application's `Assets/` in order to prevent duplicate code. Ideally, it would be the other way around. However, due to inconsistencies in how Windows supports symlinks, this can break the build (if the symlink is not recognised in a Windows development environment, the Connector namespace is missing in the demo app). For 3rd party developers to obtain the package they can copy the folder or, which is the recommended way, download the AssetPackage from a GitHub release.
 
 This package provides some scripts allow developers use it to retrieve data and load 3D objects from Storage server. It also provided a Demo scene to guide developer use this package. The detail of methods and usage of each scripts are listed below.
 
@@ -14,11 +14,11 @@ using HoloStorageConnector;
 `HoloStorageClient` script provided multiple methods to retrieve data from Storage server. For now, you could retrieve the meta data of patients, holograms and authors based on ID, and also load 3D object from the server. Please note, currently the `LoadHologram` method only load the object from a hard code uri. You have to create a coroutine to run the retrieve methods, the details could be found in example usage.
 
 |Method|Description|
-| :--- | :--- | 
+| :--- | :--- |
 |`GetMultiplePatients(List<Patient> patientList, string IDs)`|Retrieve multiple patients meta data from HoloStorage server|
 |`GetPatient(Patient patient, string patientID)`|Retrieve a single patient meta data by patient ID|
 |`GetMultipleHolograms(List<Hologram> hologramList, string IDs, QueryType queryType)`|Retrieve multiple holograms meta data from HoloStorage server. QueryType is optional, determines whether query holograms by hid or pid, could be either `QueryType.hid` or `QueryType.pid`, the default value is `QueryType.hid`|
-|`GetHologram(Hologram hologram, string holgramID)`|Retrieve a single hologram meta data by hologram ID|
+|`GetHologram(Hologram hologram, string hologramID)`|Retrieve a single hologram meta data by hologram ID|
 |`GetMultipleAuthors(List<Author> authorList, string IDs)`|Retrieve multiple authors meta data from HoloStorage server|
 |`GetAuthor(Author author, string authorID)`|Retrieve a single author meta data by author ID|
 |`LoadHologram(string hologramID, HologramInstantiationSettings setting)`|Load a Hologram object to scene by ID, Hologram instantiation settings is optional|
@@ -33,7 +33,7 @@ HoloStorageClient.LoadHologram("hid");
 }
 
 IEnumerator RetrievePatients()
-{        
+{
     List<Patient> patientList = new List<Patient>();
     yield return HoloStorageClient.GetMultiplePatients(patientList, "pids");
     //Do something here...
@@ -48,13 +48,13 @@ IEnumerator RetrievePatients()
 `HologramInstantiationSettings` script allow users to set the transform settings before load the 3D object from server, for example, set the position, rotation and scale of the 3D object, you can also determine whether the object could be manipulated or which scene you want to load.
 
 |Properties|Description|
-| :--- | :--- | 
+| :--- | :--- |
 |`Name`|Set a name for the loaded model. Default value is "LoadedModel"|
 |`Position`|Set position for the loaded model, the value should be a Vector3 object. Default value is (0, 0, 0)|
 |`Rotation`|Set rotation for the loaded model, the parameter should be a Vector3 object. Default value is (0, 0, 0)|
 |`Size`|Real size in the scene, The longest side of the loaded object will be set to this value. Default value is 0.5f|
 |`Manipulable`|Determine whether the object could be manipulated. Default setting is true|
-|`SeceneName`|Determine which scene you want to load the object. Default value is null, which means the object will be loaded to the current active scene|
+|`SceneName`|Determine which scene you want to load the object. Default value is null, which means the object will be loaded to the current active scene|
 
 Example usage:
 
@@ -74,10 +74,10 @@ void LoadModel()
 ```
 
 ## HoloStorageEntities
-`HoloStorageEntities` script is used to define the related HoloStorage entities, make it easier to map the information from json data. 
+`HoloStorageEntities` script is used to define the related HoloStorage entities, make it easier to map the information from json data.
 
 |Classes|Description|
-| :--- | :--- | 
+| :--- | :--- |
 |`Patient`|Patient object, contains the basic information of the patient, like id, name, date of birth and gender|
 |`Hologram`|Hologram object, contains the basic information of the hologram, like title, create date and description|
 |`Author`|Author of the Hologram, contains the ID and name of the author|
@@ -94,7 +94,7 @@ You could add this list view to you scene, choose the information type that you 
 </p>
 
 ### HologramLoader
-Drag this prefab into you scene, and set the related options in the inspector. In the play mode, it will load the hologram to you scene. 
+Drag this prefab into you scene, and set the related options in the inspector. In the play mode, it will load the hologram to you scene.
 <p align="center">
     <img src="../HoloRepositoryDemoApplication/Images/HologramLoader.png">
 </p>
@@ -104,7 +104,7 @@ Drag this prefab into you scene, and set the related options in the inspector. I
     <img src="../HoloRepositoryDemoApplication/Images/DemoScene.png" height="400">
 </p>
 
-This package also provided some demo scene to guide the developer how to use this package, which you can find [here](../HoloRepositoryDemoApplication/Assets/HoloStorageConnector/Demo). You could follow the StorageConnectorDemo scene and demo script to learn the basic usage of the HoloStorageConnector package. There is also a prefab scene to demostrate how to use the prefabs, feel free to explore.
+This package also provided some demo scene to guide the developer how to use this package, which you can find [here](../HoloRepositoryDemoApplication/Assets/HoloStorageConnector/Demo). You could follow the StorageConnectorDemo scene and demo script to learn the basic usage of the HoloStorageConnector package. There is also a prefab scene to demonstrate how to use the prefabs, feel free to explore.
 
 Note: You have to import the TMP Essentials when you open the scenes at first time, just follow the guide in the window.
 
@@ -115,5 +115,5 @@ Note: You have to import the TMP Essentials when you open the scenes at first ti
 ## Technologies
 The following technologies are used in this component:
 * [SimpleJSON](https://wiki.unity3d.com/index.php/SimpleJSON) is used to parse the JSON data.
-* [Unity 2018.4.2f1](https://unity3d.com/unity/whats-new/2018.4.2) is the main platform to develop the HoloLens app and connector package.   
+* [Unity 2018.4.2f1](https://unity3d.com/unity/whats-new/2018.4.2) is the main platform to develop the HoloLens app and connector package.
 * [MRTK v2.0.0 RC2.1](https://github.com/microsoft/MixedRealityToolkit-Unity) is an open source development kit used to develop mixed reality applications.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ To our best knowledge, there have been no projects that combine medical hologram
 This demo application is developed by Unity3D, please setup the environment before running the App:
 
 |Tools|<center>Prerequisites </center>|
-| :--- | :--- | 
+| :--- | :--- |
 | ![Windows SDK 18362+](./HoloRepositoryDemoApplication/Images/windows10_logo.png)| **Windows 10 SDK:** To run the HoloLens App, please make sure you have installed the Windows 10 SDK version 18362 or later [Download Link](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk)|
 |![Unity](./HoloRepositoryDemoApplication/Images/unity_logo.png) | **Unity3D:** The current recommendation is to use Unity 2018.4.x, which is the LTS build required for MRTK v2, The version we used to develop the App is **2018.4.2f1**, which you can download [here](https://unity3d.com/unity/whats-new/2018.4.2). Meanwhile, please make sure you have installed the **Universal Windows Platform (UWP)** and **.NET** support for unity.|
 |![Visual Studio 2017](./HoloRepositoryDemoApplication/Images/visualstudio_logo.png)| **Visual Studio 2017:** In order to support the TextMeshPro UI in Unity, please make sure your Visual Studio 2017 version is later than  15.7.5. The current using version is **15.9.14**, which is highly recommended. [Download Link](https://visualstudio.microsoft.com/downloads/) |
 |![MRTK V2.](./HoloRepositoryDemoApplication/Images/mrtkicon.jpg)| **MRTK V2.0:** Initially, the MRTK v2.0 has already been imported into this project, you don't need to import the toolkit again. if you want to develop the HoloLens App on your own, please visit their [website](https://github.com/microsoft/MixedRealityToolkit-Unity). |
 
-The detail of related development tools could be found in [microsoft mixed reality offical site](https://docs.microsoft.com/en-us/windows/mixed-reality/install-the-tools).
+The detail of related development tools could be found in [microsoft mixed reality official site](https://docs.microsoft.com/en-us/windows/mixed-reality/install-the-tools).
 
 ### Start to run the app
 Before you start to run the HoloLens App, there are some settings are required in Unity. First, if you pull the application properly from this GitHub, the menu bar should contain the MRTK option. if not, please remove the local files and pull it gain.
@@ -87,7 +87,7 @@ Use Visual Studio to open the generated **.sln** file, then Select an **x86** bu
     <img src="./HoloRepositoryDemoApplication/Images/Deploy.png" height="200">
 </p>
 
-The details of the deployment steps and other deploy methods are available in [microsoft mixed reality offical site](https://docs.microsoft.com/en-us/windows/mixed-reality/using-visual-studio).
+The details of the deployment steps and other deploy methods are available in [microsoft mixed reality official site](https://docs.microsoft.com/en-us/windows/mixed-reality/using-visual-studio).
 
 ## Code organisation
 The rest of the components of the overall project are kept in the [HoloRepository-Core](https://github.com/nbckr/HoloRepository-Core) mono-repository. The only exception are the components that are developed in Unity/C#, they are separately kept in this [HoloRepository-HoloLens](https://github.com/nbckr/HoloRepository-HoloLens) repository.


### PR DESCRIPTION
This PR fixes some typos found in the 3 READMEs in this project.

Do that note of the typo in the `SceneName` property, I did not check if that typo exists within the project itself.  